### PR TITLE
Add platform specific command lines for Windows and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Run `go run main.go start` to attach the USB device. Run `go run main.go --help`
 
 ### Linux
 
-1. Run `sudo modprobe vhci-hcd` to
-2. Run `sudo go run main.go start` to start up the USB device server.
-3. Run `sudo usbip attach -r 127.0.0.1 -b 2-2` to attach the USB device.
+Note that this tool requires elevated permissions.
+
+1. Run `sudo modprobe vhci-hcd` to load the necessary drivers.
+2. Run `sudo go run main.go start` to start up the USB device server. Authenticate when `sudo` prompts you; this is necessary to attach the device.

--- a/demo/exec_linux.go
+++ b/demo/exec_linux.go
@@ -1,0 +1,8 @@
+package demo
+
+import "os/exec"
+
+// Execute USB IP attach for Linux
+func platformUsbIPExec() *exec.Cmd {
+	return exec.Command("sudo", "usbip", "attach", "-r", "127.0.0.1", "-b", "2-2")
+}

--- a/demo/exec_windows.go
+++ b/demo/exec_windows.go
@@ -1,0 +1,6 @@
+package demo
+
+// Execute USB IP attach for Windows
+func platformUsbIPExec() *exec.Cmd {
+	return exec.Command("./usbip/usbip.exe", "attach", "-r", "127.0.0.1", "-b", "2-2")
+}

--- a/demo/server.go
+++ b/demo/server.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -78,19 +76,17 @@ func runServer(client virtual_fido.Client) {
 		virtual_fido.Start(client)
 		wg.Done()
 	}()
-	if runtime.GOOS == "windows" {
-		go func() {
-			time.Sleep(500 * time.Millisecond)
-			prog := exec.Command("./usbip/usbip.exe", "attach", "-r", "127.0.0.1", "-b", "2-2")
-			prog.Stdin = os.Stdin
-			prog.Stdout = os.Stdout
-			prog.Stderr = os.Stderr
-			err := prog.Run()
-			if err != nil {
-				fmt.Printf("Error: %s\n", err)
-			}
-			wg.Done()
-		}()
-	}
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		prog := platformUsbIPExec()
+		prog.Stdin = os.Stdin
+		prog.Stdout = os.Stdout
+		prog.Stderr = os.Stderr
+		err := prog.Run()
+		if err != nil {
+			fmt.Printf("Error: %s\n", err)
+		}
+		wg.Done()
+	}()
 	wg.Wait()
 }


### PR DESCRIPTION
This quick change makes platform specific commands for Linux and Windows. It doesn't check for the presence of the driver (or if the user can even attain `sudo` permissions) but it should fix problems for people trying to run the demo application without having to run a separate command.

My Goland install also warned about the GOOS check being faulty for some reason, I believe this approach to platform specific code should work better?