### PR TITLE
Fix vault import with different RP IDs

### DIFF
--- a/identities/identity_vault.go
+++ b/identities/identity_vault.go
@@ -104,22 +104,22 @@ func (vault *IdentityVault) Export() []SavedCredentialSource {
 }
 
 func (vault *IdentityVault) Import(sources []SavedCredentialSource) error {
-	for _, source := range sources {
-		key, err := cose.UnmarshalCOSEPrivateKey(source.PrivateKey)
+	for idx, _ := range sources {
+		key, err := cose.UnmarshalCOSEPrivateKey(sources[idx].PrivateKey)
 		if err != nil {
-			oldFormatKey, err := x509.ParseECPrivateKey(source.PrivateKey)
+			oldFormatKey, err := x509.ParseECPrivateKey(sources[idx].PrivateKey)
 			if err != nil {
 				return fmt.Errorf("Invalid private key for source: %w", err)
 			}
 			key = &cose.SupportedCOSEPrivateKey{ECDSA: oldFormatKey}
 		}
 		decodedSource := CredentialSource{
-			Type:             source.Type,
-			ID:               source.ID,
+			Type:             sources[idx].Type,
+			ID:               sources[idx].ID,
 			PrivateKey:       key,
-			RelyingParty:     &source.RelyingParty,
-			User:             &source.User,
-			SignatureCounter: source.SignatureCounter,
+			RelyingParty:     &sources[idx].RelyingParty,
+			User:             &sources[idx].User,
+			SignatureCounter: sources[idx].SignatureCounter,
 		}
 		vault.AddIdentity(&decodedSource)
 	}


### PR DESCRIPTION
When a vault contained multiple credential sources with different RP IDs, only the most recently added source could successfully be used after import.

This is because the `IdentityVault` Import function took the address of a string that resided in the copy created by a range loop. Start address of this copy is always the same for all iterations (iow, range overwrites the previous element copy). We therefore stored the same address `&source.RelyingParty` multiple times in `vault.CredentialSources` and eventually virtual-fido behaves as if only the last RP ID was imported.

A simple fix is to not use the range copies, but the range index.

Disclaimer: It's my first experience with golang, there may may be better ways to fix this...