### PR TITLE
crypto: don't panic on non-block-aligned AES-CBC input (remote DoS)

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -152,6 +152,14 @@ func EncryptAESCBC(key []byte, data []byte) []byte {
 func DecryptAESCBC(key []byte, data []byte) []byte {
 	aesCipher, err := aes.NewCipher(key)
 	util.CheckErr(err, "Could not create AES cipher")
+	// CBC requires the input to be a non-zero multiple of the block size;
+	// cipher.CryptBlocks panics otherwise. Callers may pass attacker-controlled
+	// ciphertext (e.g. CTAP ClientPIN / hmac-secret fields), so reject bad
+	// lengths instead of crashing the whole process — return nil and let the
+	// caller surface a protocol error.
+	if len(data) == 0 || len(data)%aesCipher.BlockSize() != 0 {
+		return nil
+	}
 	iv := make([]byte, aesCipher.BlockSize())
 	cbc := cipher.NewCBCDecrypter(aesCipher, iv)
 	decryptedData := make([]byte, len(data))


### PR DESCRIPTION
### Problem
`DecryptAESCBC` passes its input straight to `cipher.BlockMode.CryptBlocks`, which **panics** when the input length is not a non-zero multiple of the AES block size.

Several callers pass **attacker-controlled** ciphertext — the CTAP ClientPIN `pinHashEnc`/`newPINEnc` and the `hmac-secret` `saltEnc` — so a client can send a field of, say, 17 bytes and crash the entire authenticator process. Remote DoS over the HID transport.

### Fix
Validate the length in `DecryptAESCBC` and return `nil` for empty / non-block-multiple input instead of panicking, letting the caller surface a normal protocol error. One self-contained change in `crypto/crypto.go`; builds and existing `crypto`/`ctap` tests pass.

(Found while building on this project; happy to adjust naming/error handling to your preference.)