### PR TITLE
ctap: reject MakeCredential without rp instead of nil-deref crash

### DIFF
--- a/ctap/ctap.go
+++ b/ctap/ctap.go
@@ -205,6 +205,12 @@ func (server *CTAPServer) handleMakeCredential(data []byte) []byte {
 	err := cbor.Unmarshal(data, &args)
 	util.CheckErr(err, fmt.Sprintf("Could not decode CBOR for MAKE_CREDENTIAL: %s %v", err, data))
 	ctapLogger.Printf("MAKE CREDENTIAL: %s\n\n", args)
+	// rp is a required parameter; reject a request that omits it rather than
+	// nil-dereferencing args.RP.Name / args.RP.ID below (which crashes the process).
+	if args.RP == nil || args.RP.ID == "" {
+		ctapLogger.Printf("ERROR: MakeCredential missing rp/rp.id\n\n")
+		return []byte{byte(ctap2ErrMissingParam)}
+	}
 	var flags authDataFlags = 0
 
 	supported := false


### PR DESCRIPTION
### Problem
`handleMakeCredential` uses `args.RP.Name` (in `ApproveAccountCreation`) and `args.RP.ID` (in `makeAuthData`) without a nil check. `RP` is an optional CBOR field (`cbor:"2,keyasint,omitempty"`), so a `authenticatorMakeCredential` request that omits key 2 sets `args.RP == nil` and the dereference **panics the whole authenticator process** — a remote crash from a single malformed request.

### Fix
`rp` is required for makeCredential, so validate it up front and return `CTAP2_ERR_MISSING_PARAMETER` (0x14) when it's absent. Builds and `ctap` tests pass.